### PR TITLE
Simplified installation instructions on Android

### DIFF
--- a/src/android/README.md
+++ b/src/android/README.md
@@ -36,6 +36,13 @@ If hope to setup manually, then:
 5. Add `<plugin name='AdMob' value='com.google.cordova.plugin.admob'/>`
    to your `plugins.xml`
 
+A simplified method (tested on Cordova 3.4.0)
+
+1. Install the Google Play Services plugin:
+```cordova plugin add https://github.com/MobileChromeApps/google-play-services.git```
+2. Install _this_ plugin:
+```cordova plugin add https://github.com/floatinghotpot/cordova-plugin-admob.git```
+
 ##Using the Plugin:
 
 There are 3 calls needed to get AdMob Ads:


### PR DESCRIPTION
Google released a Google Play Services plugin for Cordova.  It simplifies installation a lot. IMO it should be included as a dependency - this would shorten the installation instructions to a single command - cordova plugin add https://github.com/floatinghotpot/cordova-plugin-admob.git
