### PR TITLE
Add dependency to com.google.playservices plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,7 @@
 
     <!-- android -->
     <platform name="android">
+        <dependency id="com.google.playservices" version=">=15.0.1"/>
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="AdMob">
                 <param name="android-package" value="com.rjfun.cordova.plugin.AdMob"/>


### PR DESCRIPTION
This eliminates the need to manually copy Google Play Services to the project
