### PR TITLE
Fix for indefinite execute calls on <= Android 4.0.4

### DIFF
--- a/src/android/AdMob.java
+++ b/src/android/AdMob.java
@@ -248,7 +248,9 @@ public class AdMob extends CordovaPlugin {
     synchronized (runnable) {
       cordova.getActivity().runOnUiThread(runnable);
       try {
-        runnable.wait();
+        if (runnable.getPluginResult() == null) {
+          runnable.wait();
+        }
       } catch (InterruptedException exception) {
         Log.w(LOGTAG, String.format("Interrupted Exception: %s", exception.getMessage()));
         return new PluginResult(Status.ERROR, "Interruption occurred when running on UI thread");
@@ -261,7 +263,7 @@ public class AdMob extends CordovaPlugin {
    * Represents a runnable for the AdMob plugin that will run on the UI thread.
    */
   private abstract class AdMobRunnable implements Runnable {
-    protected PluginResult result;
+    protected PluginResult result = null;
 
     public PluginResult getPluginResult() {
       return result;


### PR DESCRIPTION
On one of my test devices (Nexus S running 4.0.4) runOnUiThread doesn't ... you know, run on a different thread so the .wait() happens indefinitely.

I initialized the protected PluginResult in the AdMobRunnable class to null and did a check to see if it is still null before calling wait()
