### PR TITLE
Wait if plugin context is not ready (OK)

### DIFF
--- a/src/android/AdMob.java
+++ b/src/android/AdMob.java
@@ -435,11 +435,12 @@ public class AdMob extends CordovaPlugin {
       if (adView == null) {
         result = new PluginResult(Status.ERROR, "AdView is null.  Did you call createBannerView?");
       } else {
-		if (this.show) {
-			adView.setVisibility(View.VISIBLE);
-		} else {
-			adView.setVisibility(View.GONE);
-		}
+        result = new PluginResult(Status.OK);
+    if (this.show) {
+      adView.setVisibility(View.VISIBLE);
+    } else {
+      adView.setVisibility(View.GONE);
+    }
       }
       synchronized (this) {
         this.notify();


### PR DESCRIPTION
I believe this fixes the Android problem with blank ads in cordova 3.4 (It's a timing problem, so it's now reproducible on all devices)

http://stackoverflow.com/questions/22647417/admob-plugins-compatible-with-phonegap-3-4
