### PR TITLE
FIX: BannerView permanently hidden after showAd(false) on IOS #67

### DIFF
--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -157,7 +157,8 @@ interstitial:(BOOL)isInterstitial;
 		return;
 	}
 
-	BOOL adIsShowing = [self.webView.superview.subviews containsObject:self.bannerView];
+	BOOL adIsShowing = [self.webView.superview.subviews containsObject:self.bannerView] &&
+        (! self.bannerView.hidden);
 	BOOL toShow = [[arguments objectAtIndex:SHOW_AD_ARG_INDEX] boolValue];
     
 	if( adIsShowing == toShow ) { // already show or hide


### PR DESCRIPTION
Re-enable check for hidden bannerView.

Testing:
  IOS7 on iPhone5
  IOS7 on iPad3
  IOS6 on iPhone 3GS
