### PR TITLE
Fixed Android banner rendering issue.

### DIFF
--- a/src/android/AdMob.java
+++ b/src/android/AdMob.java
@@ -95,15 +95,20 @@ public class AdMob extends CordovaPlugin {
 	private boolean isGpsAvailable = false;
 
     @Override
-	public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+	public void initialize(CordovaInterface cordova, final CordovaWebView webView) {
     	super.initialize(cordova, webView);
     	isGpsAvailable = (GooglePlayServicesUtil.isGooglePlayServicesAvailable(cordova.getActivity()) == ConnectionResult.SUCCESS);
     	Log.w(LOGTAG, String.format("isGooglePlayServicesAvailable: %s",  isGpsAvailable?"true":"false"));
 
-        webView.setLayoutParams(new LinearLayout.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT,
-            1.0F));
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                webView.setLayoutParams(new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    1.0F));
+            }
+        });
 	}
 	
     /**


### PR DESCRIPTION
  By default the Cordova Webview scales to take up the entire width and
height of the Android screen. A change was made to set its height to
flex to take up the entire remaining free vertical space, instead of
taking all of it. This change was made because the AdView, when at the
bottom of the screen, was "bumping" up the WebView to take it's space.
This bumping only happened after layout in the WebView, which caused
fullscreen WebView content to visually jump up. Oddly this happened
after every reflow inside of the WebView, so on every page change you
had the content "bump" up.

  For some reason this change only fixes Android versions > 4.1. I
cannot figure out why it isn't helping on version <= 4.1. The half
solution for now is better than none at all though.
