### PR TITLE
Better handling for non-existing publisher ID

### DIFF
--- a/src/android/AdMob.java
+++ b/src/android/AdMob.java
@@ -203,8 +203,7 @@ public class AdMob extends CordovaPlugin {
         this.setOptions( options );
         autoShowBanner = autoShow;
 
-        if(publisherId==null || publisherId=="") publisherId = getTempBanner();
-        if(this.publisherId.indexOf("xxxx") > 0){
+        if(publisherId==null || publisherId=="" || publisherId.indexOf("xxxx") > 0){
             Log.e("banner", "Please put your admob id into the javascript code. No ad to display.");
             return null;
         }
@@ -277,8 +276,7 @@ public class AdMob extends CordovaPlugin {
         this.setOptions( options );
         autoShowInterstitial = autoShow;
 
-        if(interstialAdId==null || interstialAdId=="") interstialAdId = getTempInterstitial();
-        if(this.interstialAdId.indexOf("xxxx") > 0){
+        if(interstialAdId==null || interstialAdId=="" || interstialAdId.indexOf("xxxx") > 0){
             Log.e("interstitial", "Please put your admob id into the javascript code. No ad to display.");
             return null;
         }
@@ -657,13 +655,6 @@ public class AdMob extends CordovaPlugin {
                 break;
         }
         return errorReason;
-    }
-
-    private String getTempInterstitial(){
-        return "ca-app-pub-6869992474017983/1657046752";
-    }
-    private String getTempBanner(){
-        return "ca-app-pub-6869992474017983/9375997553";
     }
 
     public static final String md5(final String s) {

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -124,9 +124,9 @@ object:nil];
 
     bannerShow = true;
 
-    publisherId = [self getTestBannerId];
+    publisherId = nil;
 
-    interstitialAdId = [self getTestInterstitialId];
+    interstitialAdId = nil;
 
     adSize = [self __AdSizeFromString:@"SMART_BANNER"];
 
@@ -695,9 +695,7 @@ return kGADAdSizeInvalid;
 
     
 
-    if (!self.bannerView){
-
-        if(publisherId == nil) publisherId = [self getTestBannerId];
+    if (!self.bannerView && publisherId != nil){
 
         self.bannerView = [[GADBannerView alloc] initWithAdSize:adSize];
 
@@ -856,9 +854,7 @@ self.bannerIsVisible = NO;
 
     // and create a new interstitial. We set the delegate so that we can be notified of when
 
-    if (!self.interstitialView){
-
-        if(interstitialAdId == nil) interstitialAdId = [self getTestInterstitialId];
+    if (!self.interstitialView && interstitialAdId != nil){
 
         self.interstitialView = [[GADInterstitial alloc] init];
 
@@ -1166,15 +1162,6 @@ if( self.bannerView ) {
 
 }
 
-- (NSString*) getTestBannerId
-{
-  return @"ca-app-pub-6869992474017983/4806197152";
-}
-
-- (NSString*) getTestInterstitialId
-{
-  return @"ca-app-pub-6869992474017983/7563979554";
-}
 
 #pragma mark Cleanup
 

--- a/src/wp8/AdMob.cs
+++ b/src/wp8/AdMob.cs
@@ -260,7 +260,7 @@ namespace Cordova.Extension.Commands
 			
 			if (bannerAd == null)
 			{
-                if(publisherId == null || publisherId == "") publisherId = getTestBanner();
+                if(publisherId == null || publisherId == "") return;
 				
 				// Asynchronous UI threading call
 				Deployment.Current.Dispatcher.BeginInvoke(() =>
@@ -393,7 +393,7 @@ namespace Cordova.Extension.Commands
 			
 			if (interstitialAd == null)
 			{
-				if(interstitialAdId == null || interstitialAdId=="") interstitialAdId = getTestInterstitial();
+				if(interstitialAdId == null || interstitialAdId=="") return;
 				
 				// Asynchronous UI threading call
 				Deployment.Current.Dispatcher.BeginInvoke(() =>
@@ -1148,15 +1148,6 @@ namespace Cordova.Extension.Commands
 			
 			return AdFormats.SmartBanner;
 		}
-      
-        private string getTestBanner()
-        {
-          return "ca-app-pub-6869992474017983/8878394753";
-        }
-        private string getTestInterstitial()
-        {
-          return "ca-app-pub-6869992474017983/1355127956";
-        }
 
         /// <summary>
 		/// Parses simple jason object into a map of key value pairs


### PR DESCRIPTION
Commit f38a9cf559b1941255e75d68b33543223e748922 removed ad traffic sharing. By default, the test banner ID was loaded. This could lead to "unintentional" traffic sharing when configuring the plugin in the wrong way. Now, the banner won't be created if no publisher ID was provided.

(I haven't been able to test the wp8 part. But I am pretty confident it should work :smiley:)