### PR TITLE
Compatibility with recent Ads SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,36 @@ See full index.html: https://github.com/floatinghotpot/cordova-plugin-admob/blob
 
 Note: This plugin is quite stable, and will not be evolved any more, except upgrade AdMob SDK.
 
+### Additional Android Manifest Configuration
+
+Recent versions of the Android Google Mobile Ads SDK [require to add the AdMob app ID into the Android manifest file.](https://ads-developers.googleblog.com/2018/10/announcing-v1700-of-android-google.html)
+
+This can be accomplished by [extending your Cordova `config.xml` as follows:](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#config-file)
+
+```xml
+<widget ...>
+    [...]
+    <platform name="android">
+        [...]
+        <config-file parent="/manifest/application" target="AndroidManifest.xml">
+            <!-- TODO: Replace with your real AdMob app ID -->
+            <meta-data
+                android:name="com.google.android.gms.ads.APPLICATION_ID"
+                android:value="ca-app-pub-################~##########"/>
+        </config-file>
+    </platform>
+    [...]
+</widget>
+```
+
+When using Google Ad Manager, use instead:
+
+```xml
+            <meta-data
+                android:name="com.google.android.gms.ads.AD_MANAGER_APP"
+                android:value="true" />
+```
+
 ## AdMob Basic vs Pro
 
 If you want to use more powerful and new features, please use the pro version instead. The totoally re-designed **[AdMob PluginPro](https://github.com/floatinghotpot/cordova-admob-pro)** is proved much better and more than welcome by Cordova APP/game developers. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-admob",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "The FASTEST and EASIEST TO USE Cordova Admob plugin for Android, iOS and Windows phone. Pure open source without any traffic sharing. Allows preloading and automatic loading of interstitials and banners plus more. Works with Cordova, Phonegap, Intel XDK/Crosswalk, Ionic, Meteor and more.",
   "cordova": {
     "id": "cordova-plugin-admob",

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
         <clobbers target="window.plugins.AdMob" />
     </js-module>
 
-    <dependency id="cordova-admobsdk" version="1.0.3" />
+    <dependency id="cordova-admobsdk" version="1.0.4" />
 
     <!-- android -->
     <!-- android, now build with gradle instead of ant -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
         <clobbers target="window.plugins.AdMob" />
     </js-module>
 
-    <dependency id="cordova-admobsdk"/>
+    <dependency id="cordova-admobsdk" version="1.0.3" />
 
     <!-- android -->
     <!-- android, now build with gradle instead of ant -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	id="cordova-plugin-admob"
-	version="3.2.4">
+	version="3.2.5">
       
     <name>Cordova-Phonegap AdMob Plugin</name>
 	<description>The FASTEST and EASIEST TO USE Cordova Admob plugin for Android, iOS and Windows phone. Pure OpenSource. Allows preloading and automatic loading of interstitials and banners plus more. Works with Cordova, Phonegap, Intel XDK/Crosswalk, Ionic, Meteor and more.</description>

--- a/src/android/AdMob.java
+++ b/src/android/AdMob.java
@@ -13,7 +13,6 @@ import android.widget.RelativeLayout;
 import com.google.android.gms.ads.*;
 import com.google.android.gms.ads.mediation.admob.AdMobExtras;
 import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GooglePlayServicesUtil;
 
 import org.apache.cordova.*;
 import org.apache.cordova.PluginResult.Status;
@@ -94,7 +93,6 @@ public class AdMob extends CordovaPlugin {
     private boolean autoShowInterstitialTemp = false;		//if people call it when it's not ready
 
     private boolean bannerVisible = false;
-    private boolean isGpsAvailable = false;
 
     SharedPreferences settings;
     SharedPreferences.Editor editor;
@@ -107,9 +105,6 @@ public class AdMob extends CordovaPlugin {
 
         settings = PreferenceManager.getDefaultSharedPreferences(this.cordova.getActivity().getApplicationContext());
         editor = settings.edit();
-
-        isGpsAvailable = (GooglePlayServicesUtil.isGooglePlayServicesAvailable(cordova.getActivity()) == ConnectionResult.SUCCESS);
-        Log.w(LOGTAG, String.format("isGooglePlayServicesAvailable: %s", isGpsAvailable ? "true" : "false"));
     }
 
     /**
@@ -587,7 +582,6 @@ public class AdMob extends CordovaPlugin {
     @Override
     public void onResume(boolean multitasking) {
         super.onResume(multitasking);
-        isGpsAvailable = (GooglePlayServicesUtil.isGooglePlayServicesAvailable(cordova.getActivity()) == ConnectionResult.SUCCESS);
         if (adView != null) {
             adView.resume();
         }


### PR DESCRIPTION
The pull request covers the following issues:

* Added specific version reference 1.0.4 for `cordova-admobsdk` dependency (recent version is not compatible with `cordova-plugin-admob`)
* Removed use of deprecated `GooglePlayServicesUtil.isGooglePlayServicesAvailable` (build failed with recent Android Google Mobile Ads SDK)
* Extended README about Android Manifest config required by recent Android Google Mobile Ads SDK
* Increased version for publishing on NPM

I kindly request pulling it to the main repository and publishing the new version on NPM. Thanks again for your great work, @floatinghotpot.